### PR TITLE
Allow upper case suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactmaker/react-autocorrect-input",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reactmaker/react-autocorrect-input",
   "description": "Autocorrect input react component, suggested text when you type in.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "bin/Input.js",
   "repository": {
     "type": "git",

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -151,7 +151,7 @@ export default class ACInput extends React.PureComponent {
           style={style}
           className={className}
         />
-        <Style.MenuContainer display={displaySuggest} className={menuClassName}>
+        <Style.MenuContainer display={displaySuggest.toString()} className={menuClassName}>
           {
             suggest.map(keyword => (
               <Style.MenuLi

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -57,28 +57,19 @@ const initState = {
   selectedSuggest: '',
 };
 
-export default class ACInput extends React.Component {
+export default class ACInput extends React.PureComponent {
   inputRef = React.createRef()
 
   state = initState
 
   onChange = (e) => {
     const { dataSource, onChange } = this.props;
-    const { value, selectionStart } = e.target;
-    // 1. get last keyword
-    const lastWord = value.split(' ').pop().toLowerCase();
-    if (!lastWord || selectionStart !== value.length) {
-      this.setState(initState);
-      onChange(value);
-      return;
-    }
-    // 2. filter suggest
+    const { value } = e.target;
+    // 1. filter suggest
     const suggest = dataSource
-      .map(keyword => keyword.toLowerCase())
-      .filter(keyword => (keyword.indexOf(lastWord) === 0))
-      .slice(0, 10);
+      .filter(keyword => (keyword.toLowerCase().indexOf(value.toLowerCase()) > -1))
     const selectedSuggest = suggest[0] || '';
-    // 3. update suggest array
+    // 2. update suggest array
     this.setState({ suggest, selectedSuggest });
     onChange(value);
   }

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -67,7 +67,7 @@ export default class ACInput extends React.PureComponent {
     const { value } = e.target;
     // 1. filter suggest
     const suggest = dataSource
-      .filter(keyword => (keyword.toLowerCase().indexOf(value.toLowerCase()) > -1))
+      .filter(keyword => (keyword.toLowerCase().indexOf(value.toLowerCase()) > -1));
     const selectedSuggest = suggest[0] || '';
     // 2. update suggest array
     this.setState({ suggest, selectedSuggest });


### PR DESCRIPTION
I think it would make more sense to perform conversions to lower case on the filtering instead of the data itself. This allows upper case characters to be used when a suggestion is clicked.

I have also fixed a minor errors that appears in the console.